### PR TITLE
fix: Pin tokendito version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM base as builder
 RUN mkdir /install
 WORKDIR /install
 
-RUN pip install --prefix=/install --no-cache-dir --no-warn-script-location tokendito mintotp
+RUN pip install --prefix=/install --no-cache-dir --no-warn-script-location 'tokendito>=1,<2' mintotp
 
 FROM base
 COPY --from=builder /install /usr/local


### PR DESCRIPTION
Ensure that Tokendito will not install the latest version as upcoming changes may create an incompatible CLI.