### PR TITLE
Overwrite the aws config instead of appending

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ Obtain temporary AWS Creds from your Okta Profile.
 
 ## Usage
 
-Here's an example. All options are required except `okta_mfa_method` which default to TOTP based notification.
+Here's an example. All options are required except:
+- `aws_profile` defaults to 'default'
+- `okta_mfa_method` which default to TOTP based notification.
 
 ```yaml
 - name: Create AWS profile
@@ -26,6 +28,35 @@ AWS_SESSION_TOKEN: ***
 ```
 
 It also masks the actual values in the logs for added security.
+
+
+You can create multiple profiles by using this action multiple times and specifying `aws_profile` for each like such:
+```yaml
+- name: Create First AWS profile
+  uses: mrchief/aws-creds-okta@master
+  with:
+    aws_profile: first-profile
+    aws_role_arn: arn:aws:iam::account-id:role/role-name
+    okta_username: okta.user@mycompany.com
+    okta_password: ${{ secrets.OKTA_PASSWORD }}
+    okta_app_url: https://mycompany.okta.com/home/amazon_aws/1234567890abcdefghij/123
+    okta_mfa_seed: ${{ secrets.OKTA_MFA_SEED }}
+
+- name: Create Second AWS profile
+  uses: mrchief/aws-creds-okta@master
+  with:
+    aws_profile: second-profile
+    aws_role_arn: arn:aws:iam::account-id:role/role-name
+    okta_username: okta.user@mycompany.com
+    okta_password: ${{ secrets.OKTA_PASSWORD }}
+    okta_app_url: https://mycompany.okta.com/home/amazon_aws/1234567890abcdefghij/123
+    okta_mfa_seed: ${{ secrets.OKTA_MFA_SEED }}
+
+- name: Run AWS Commands as Different Profiles
+  run: |
+    aws sts get-caller-identity --profile first-profile
+    aws sts get-caller-identity --profile second-profile
+```
 
 ### 💡 Note
 

--- a/README.md
+++ b/README.md
@@ -4,12 +4,10 @@ Obtain temporary AWS Creds from your Okta Profile.
 
 ## Usage
 
-Here's an example. All options are required except:
-- `aws_profile` defaults to 'default'
-- `okta_mfa_method` which default to TOTP based notification.
+Here's an example. All options are required except `okta_mfa_method` which default to TOTP based notification.
 
 ```yaml
-- name: Create AWS profile
+- name: Get AWS Credentials
   uses: mrchief/aws-creds-okta@master # or a tagged release version
   with:
     aws_role_arn: arn:aws:iam::account-id:role/role-name
@@ -29,40 +27,12 @@ AWS_SESSION_TOKEN: ***
 
 It also masks the actual values in the logs for added security.
 
-
-You can create multiple profiles by using this action multiple times and specifying `aws_profile` for each like such:
-```yaml
-- name: Create First AWS profile
-  uses: mrchief/aws-creds-okta@master
-  with:
-    aws_profile: first-profile
-    aws_role_arn: arn:aws:iam::account-id:role/role-name
-    okta_username: okta.user@mycompany.com
-    okta_password: ${{ secrets.OKTA_PASSWORD }}
-    okta_app_url: https://mycompany.okta.com/home/amazon_aws/1234567890abcdefghij/123
-    okta_mfa_seed: ${{ secrets.OKTA_MFA_SEED }}
-
-- name: Create Second AWS profile
-  uses: mrchief/aws-creds-okta@master
-  with:
-    aws_profile: second-profile
-    aws_role_arn: arn:aws:iam::account-id:role/role-name
-    okta_username: okta.user@mycompany.com
-    okta_password: ${{ secrets.OKTA_PASSWORD }}
-    okta_app_url: https://mycompany.okta.com/home/amazon_aws/1234567890abcdefghij/123
-    okta_mfa_seed: ${{ secrets.OKTA_MFA_SEED }}
-
-- name: Run AWS Commands as Different Profiles
-  run: |
-    aws sts get-caller-identity --profile first-profile
-    aws sts get-caller-identity --profile second-profile
-```
-
 ### 💡 Note
 
 - Currently only supports `totp` authentication. There are plans to add support for other MFA methods. PRs welcome.
 - `okta_app_url` can be obtained by right clicking the Okta tile for you AWS account. This setup allows for federated login to different AWS accounts.
 - `okta_password` & `okta_mfa_seed` can be set via environment variables `${{ env.OKTA_MFA_SEED }}` although it is not recommended to do so as it can leak secrets. Github repo secrets are the easiest way but if you manage secrets via some other mechanism, you can also use them - these are just normal inputs, you can pass them anything.
+- If you run this action multiple times, you will receive new credentials each time, even if you specify the same role arn. This is because we cannot create an aws config or credentials file from the action that is accessible in the workflow. This also means we cannot support profiles.
 
 ## Can I use this
 

--- a/action.yml
+++ b/action.yml
@@ -4,10 +4,6 @@ inputs:
   aws_role_arn:
     description: "ARN of federated Okta role"
     required: true
-  aws_profile:
-    description: "The AWS profile to configure"
-    required: false
-    default: "default"
   okta_username:
     description: "Username of your Okta login (usually your email)"
     required: true

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,10 @@ inputs:
   aws_role_arn:
     description: "ARN of federated Okta role"
     required: true
+  aws_profile:
+    description: "The AWS profile to configure"
+    required: false
+    default: "default"
   okta_username:
     description: "Username of your Okta login (usually your email)"
     required: true

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,7 +8,7 @@ config="${awsDir}/config"
 credentials="${awsDir}/credentials"
 
 mkdir -p "${awsDir}"
-echo -e "[profile default]\noutput = json" >>"$config"
+echo -e "[profile default]\noutput = json" >"$config"
 
 # Attempt to get aws credentials via tokendito
 max_attempts=10

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,11 +8,7 @@ config="${awsDir}/config"
 credentials="${awsDir}/credentials"
 
 mkdir -p "${awsDir}"
-echo -e "[profile $INPUT_AWS_PROFILE]\noutput = json" >>"$config"
-
-echo "AWS_CONFIG_FILE=${config}" >> $GITHUB_ENV
-echo "AWS_SHARED_CREDENTIALS_FILE=${credentials}" >> $GITHUB_ENV
-echo "AWS_PROFILE=${INPUT_AWS_PROFILE}" >> $GITHUB_ENV
+echo -e "[profile default]\noutput = json" >"$config"
 
 # Attempt to get aws credentials via tokendito
 max_attempts=10
@@ -20,7 +16,7 @@ totp_time=30
 totp_error='Each code can only be used once. Please wait for a new code and try again.'
 for ((attempts = 1; attempts <= $max_attempts; attempts++)); do
     echo "Requesting AWS credentials via Tokendito."
-    t_error=$(tokendito --aws-profile $INPUT_AWS_PROFILE -ou $INPUT_OKTA_APP_URL -R $INPUT_AWS_ROLE_ARN --username $INPUT_OKTA_USERNAME --password $INPUT_OKTA_PASSWORD --mfa-method ${INPUT_OKTA_MFA_METHOD:=token:software:totp} --mfa-response $(echo $INPUT_OKTA_MFA_SEED | mintotp ${totp_time}) 2>&1 1>/dev/null)
+    t_error=$(tokendito --aws-profile default -ou $INPUT_OKTA_APP_URL -R $INPUT_AWS_ROLE_ARN --username $INPUT_OKTA_USERNAME --password $INPUT_OKTA_PASSWORD --mfa-method ${INPUT_OKTA_MFA_METHOD:=token:software:totp} --mfa-response $(echo $INPUT_OKTA_MFA_SEED | mintotp ${totp_time}) 2>&1 1>/dev/null)
 
     if [[ $? == 0 ]]; then
         echo "Succeeded getting credentials in attempt #${attempts}."
@@ -54,7 +50,7 @@ while read -r line; do
         section="${section#[}"
     fi
     # Extract available aws export values
-    if [ "${section}" = $INPUT_AWS_PROFILE ]; then
+    if [ "${section}" = "default" ]; then
         if [[ "${line}" =~ ^[[:space:]]*aws_access_key_id[[:space:]]*=.*$ ]]; then
             aws_access_key_id="${line##*=*[[:space:]]}"
             echo "AWS_ACCESS_KEY_ID=${aws_access_key_id}" >> $GITHUB_ENV

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,7 +8,7 @@ config="${awsDir}/config"
 credentials="${awsDir}/credentials"
 
 mkdir -p "${awsDir}"
-echo -e "[profile default]\noutput = json" >"$config"
+echo -e "[profile $INPUT_AWS_PROFILE]\noutput = json" >>"$config"
 
 # Attempt to get aws credentials via tokendito
 max_attempts=10
@@ -16,7 +16,7 @@ totp_time=30
 totp_error='Each code can only be used once. Please wait for a new code and try again.'
 for ((attempts = 1; attempts <= $max_attempts; attempts++)); do
     echo "Requesting AWS credentials via Tokendito."
-    t_error=$(tokendito --aws-profile default -ou $INPUT_OKTA_APP_URL -R $INPUT_AWS_ROLE_ARN --username $INPUT_OKTA_USERNAME --password $INPUT_OKTA_PASSWORD --mfa-method ${INPUT_OKTA_MFA_METHOD:=token:software:totp} --mfa-response $(echo $INPUT_OKTA_MFA_SEED | mintotp ${totp_time}) 2>&1 1>/dev/null)
+    t_error=$(tokendito --aws-profile $INPUT_AWS_PROFILE -ou $INPUT_OKTA_APP_URL -R $INPUT_AWS_ROLE_ARN --username $INPUT_OKTA_USERNAME --password $INPUT_OKTA_PASSWORD --mfa-method ${INPUT_OKTA_MFA_METHOD:=token:software:totp} --mfa-response $(echo $INPUT_OKTA_MFA_SEED | mintotp ${totp_time}) 2>&1 1>/dev/null)
 
     if [[ $? == 0 ]]; then
         echo "Succeeded getting credentials in attempt #${attempts}."

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,6 +10,10 @@ credentials="${awsDir}/credentials"
 mkdir -p "${awsDir}"
 echo -e "[profile $INPUT_AWS_PROFILE]\noutput = json" >>"$config"
 
+echo "AWS_CONFIG_FILE=${config}" >> $GITHUB_ENV
+echo "AWS_SHARED_CREDENTIALS_FILE=${credentials}" >> $GITHUB_ENV
+echo "AWS_PROFILE=${INPUT_AWS_PROFILE}" >> $GITHUB_ENV
+
 # Attempt to get aws credentials via tokendito
 max_attempts=10
 totp_time=30
@@ -50,7 +54,7 @@ while read -r line; do
         section="${section#[}"
     fi
     # Extract available aws export values
-    if [ "${section}" = "default" ]; then
+    if [ "${section}" = $INPUT_AWS_PROFILE ]; then
         if [[ "${line}" =~ ^[[:space:]]*aws_access_key_id[[:space:]]*=.*$ ]]; then
             aws_access_key_id="${line##*=*[[:space:]]}"
             echo "AWS_ACCESS_KEY_ID=${aws_access_key_id}" >> $GITHUB_ENV


### PR DESCRIPTION
We have a workflow in which we need to run this action multiple times to login to multiple aws accounts. On the second run, appending another default profile will cause an error.

Overwriting the aws config instead of just appending to it.