### PR TITLE
#17 - Write aws config file to a temporary directory

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,11 +4,14 @@ set -u
 set -o pipefail
 
 awsDir="${HOME}/.aws"
-config="${awsDir}/config"
+config="$(mktemp)"
 credentials="${awsDir}/credentials"
 
+# Delete the temporary file when this script finishes running, is interrupted, or exits abnormally
+trap "rm -f $config" 0 2 3 15
+
 mkdir -p "${awsDir}"
-echo -e "[profile default]\noutput = json" >>"$config"
+echo -e "[profile default]\noutput = json" >"$config"
 
 # Attempt to get aws credentials via tokendito
 max_attempts=10
@@ -16,7 +19,7 @@ totp_time=30
 totp_error='Each code can only be used once. Please wait for a new code and try again.'
 for ((attempts = 1; attempts <= $max_attempts; attempts++)); do
     echo "Requesting AWS credentials via Tokendito."
-    t_error=$(tokendito --aws-profile default -ou $INPUT_OKTA_APP_URL -R $INPUT_AWS_ROLE_ARN --username $INPUT_OKTA_USERNAME --password $INPUT_OKTA_PASSWORD --mfa-method ${INPUT_OKTA_MFA_METHOD:=token:software:totp} --mfa-response $(echo $INPUT_OKTA_MFA_SEED | mintotp ${totp_time}) 2>&1 1>/dev/null)
+    t_error=$(tokendito --config-file $config --aws-profile default -ou $INPUT_OKTA_APP_URL -R $INPUT_AWS_ROLE_ARN --username $INPUT_OKTA_USERNAME --password $INPUT_OKTA_PASSWORD --mfa-method ${INPUT_OKTA_MFA_METHOD:=token:software:totp} --mfa-response $(echo $INPUT_OKTA_MFA_SEED | mintotp ${totp_time}) 2>&1 1>/dev/null)
 
     if [[ $? == 0 ]]; then
         echo "Succeeded getting credentials in attempt #${attempts}."


### PR DESCRIPTION
This is to clean up the config file so that non-ephemeral runners do not fail on subsequent runs of this action as requested in #17.  Tested this in a private repo with non-ephemeral runners and it worked like a charm.

This log file doesn't really show much since I didn't change the output at all, but it does show that it worked from my branch:

```
Run mrmeyers99/aws-creds-okta-action@feat/use-temp-file
  with:
    aws_role_arn: arn:aws:iam::***:role/***
    okta_username: ***
    okta_password: ***
    okta_app_url: ***
    okta_mfa_method: token:software:totp
  env:
    ANSIBLE_FORCE_COLOR: 1
/usr/bin/docker run --name dc4f4dd0c7b2bc72b54f0787832066113a01f6_1a2cd6 --label dc4f4d --workdir /github/workspace --rm -e ANSIBLE_FORCE_COLOR -e INPUT_AWS_ROLE_ARN -e INPUT_OKTA_USERNAME -e INPUT_OKTA_PASSWORD -e INPUT_OKTA_APP_URL -e INPUT_OKTA_MFA_SEED -e INPUT_OKTA_MFA_METHOD -e HOME -e GITHUB_JOB -e GITHUB_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_REPOSITORY_OWNER -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RETENTION_DAYS -e GITHUB_ACTOR -e GITHUB_WORKFLOW -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GITHUB_EVENT_NAME -e GITHUB_SERVER_URL -e GITHUB_API_URL -e GITHUB_GRAPHQL_URL -e GITHUB_WORKSPACE -e GITHUB_ACTION -e GITHUB_EVENT_PATH -e GITHUB_ACTION_REPOSITORY -e GITHUB_ACTION_REF -e GITHUB_PATH -e GITHUB_ENV -e RUNNER_OS -e RUNNER_TOOL_CACHE -e RUNNER_TEMP -e RUNNER_WORKSPACE -e ACTIONS_RUNTIME_URL -e ACTIONS_RUNTIME_TOKEN -e ACTIONS_CACHE_URL -e GITHUB_ACTIONS=true -e CI=true -v "/var/run/docker.sock":"/var/run/docker.sock" -v "/home/ec2-user/actions-runner/_work/_temp/_github_home":"/github/home" -v "/home/ec2-user/actions-runner/_work/_temp/_github_workflow":"/github/workflow" -v "/home/ec2-user/actions-runner/_work/_temp/_runner_file_commands":"/github/file_commands" -v "/home/ec2-user/actions-runner/_work/***":"/github/workspace" dc4f4d:d0c7b2bc72b54f0787832066113a01f6
Requesting AWS credentials via Tokendito.
Succeeded getting credentials in attempt #1.```